### PR TITLE
float the right banner to the.... right

### DIFF
--- a/style.css
+++ b/style.css
@@ -712,6 +712,7 @@ h2.lh {
 .right-col {
   width: 300px;
   display: block;
+  float:right;
 }
 #inner .right-col {
   padding-top: 28px;


### PR DESCRIPTION
The right column banner that has the author details is floating  in the middle of that page. I think a float was removed accidentally.
