### PR TITLE
move fellowship sidebar to a fellowship widget

### DIFF
--- a/fellowship.php
+++ b/fellowship.php
@@ -29,6 +29,6 @@ get_header(); ?>
 
   </div>
 <div class="right-col">
-<a href="/fellows/apply/"><div class="btn apply">Apply for the fellowship &raquo;</div></a>
-<?php get_sidebar(); ?>
+<?php  if ( ! dynamic_sidebar( 'fellowship-widget-area' ) ) : ?>
+<?php endif; // end primary widget area ?>
 <?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -412,6 +412,16 @@ function twentyten_widgets_init() {
 		'before_title' => '<h3 class="widget-title">',
 		'after_title' => '</h3>',
 	) );
+    // widght on fellowship pages only
+	register_sidebar( array(
+		'name' => __( 'Fellowship Widget Area', 'twentyten' ),
+		'id' => 'fellowship-widget-area',
+		'description' => __( 'The fellowship widget area', 'twentyten' ),
+		'before_widget' => '<div style="margin-bottom: 15px;">',
+		'after_widget' => '</div>',
+		'before_title' => '',
+		'after_title' => '',
+	) );
 
 	// Area 3, located in the footer. Empty by default.
 	register_sidebar( array(


### PR DESCRIPTION
After this, the content for the fellowship sidebar needs to be set in an widget (called fellowship-widget-area), just like the current side bar.
