### PR TITLE
Strip out captions and newlines from post description

### DIFF
--- a/inc/helper.php
+++ b/inc/helper.php
@@ -63,7 +63,13 @@ if ( ! function_exists( 'get_the_excerpt_by_id' ) ) {
 		}
 
 		$the_excerpt = strip_tags($the_excerpt);
+		// Many posts start with photos/captions. Remove everything inside the [caption] tags so we get the words
+		$the_excerpt = preg_replace("/\\[caption.*\\[\\/caption\\]/", '', $the_excerpt);
+		// Strip newlines out of the string
+		$the_excerpt = trim(preg_replace('/\s\s+/', '', $the_excerpt));
+		// Trim the string to the correct $length
 		$the_excerpt = substr($the_excerpt, 0, $length);
+		// Add some dots on the end
 		$the_excerpt .= '...';
 
 		return $the_excerpt;


### PR DESCRIPTION
Currently, when we place photos inline at the top of blog posts, Facebook and others are getting our [caption] tag instead of the first sentence of content. 

This should fix that problem, and strip out unnecessary newlines, giving social sites the right juice when we post blogs.