### PR TITLE
Fix broken alignment for category in post meta

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,6 +108,7 @@
 	color: #999595;
 	font-size: 12px;
 	vertical-align: top;
+	display: flex;
 }
 .post-preview .filed ul{
 	float: none;


### PR DESCRIPTION
I'm sure there's a better way to fix this, ideally wrapping the "Filed Under" text in its own tag, but this seemed like a useful quick fix.

Alignment issue experienced with Firefox 35.0.1:

![screen shot 2015-02-24 at 12 19 21 am](https://cloud.githubusercontent.com/assets/183402/6343752/65fe54a2-bbbc-11e4-999b-c2dd4b2211a3.png)

With `display:flex`:

![screen shot 2015-02-24 at 12 19 58 am](https://cloud.githubusercontent.com/assets/183402/6343756/731937ec-bbbc-11e4-9a5b-d33460791c11.png)
